### PR TITLE
feat(reauth): Add automatic reauthentication

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustblox"
 description = "A Rust library for interacting with the Roblox API"
-version = "0.4.0"
+version = "0.5.0-dev"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/LawsOfScience/rustblox"
@@ -18,6 +18,7 @@ opt-level = 1
 opt-level = 3
 
 [dependencies]
+async-recursion = "1.0.0"
 log = "0.4.17"
 reqwest = { version = "0.11.12", features = ["json"] }
 serde = { version = "1.0.147", default-features = false, features = ["derive"] }

--- a/src/client/builder.rs
+++ b/src/client/builder.rs
@@ -4,6 +4,7 @@ use crate::error::ClientError;
 pub struct RustbloxClientBuilder {
     reqwest_builder: reqwest::ClientBuilder,
     roblox_cookie: Option<String>,
+    auto_reauth: bool,
 }
 
 impl Default for RustbloxClientBuilder {
@@ -18,6 +19,20 @@ fn get_user_agent() -> String {
 }
 
 impl RustbloxClientBuilder {
+    /// Sets whether or not the client should automatically reauthenticate itself if the Roblox
+    /// API returns a 403 status code.
+    /// The RustbloxClient will only attempt reauthentication once (see the definition of insanity
+    /// for why).
+    ///
+    /// # Errors
+    ///
+    /// This function cannot error.
+    #[inline]
+    pub fn automatic_reauthentication(mut self, auto_reauth: bool) -> Self {
+        self.auto_reauth = auto_reauth;
+        self
+    }
+
     /// Attempts to use a `RustbloxClientBuilder` to construct a `RustbloxClient`. This method will fail if reqwest fails to build a client.
     ///
     /// # Errors
@@ -33,6 +48,7 @@ impl RustbloxClientBuilder {
             reqwest_client: built_client,
             roblox_cookie: self.roblox_cookie,
             csrf_token: None,
+            auto_reauth: self.auto_reauth,
         })
     }
 
@@ -63,6 +79,7 @@ impl RustbloxClientBuilder {
         Self {
             reqwest_builder: reqwest::ClientBuilder::new().user_agent(get_user_agent()),
             roblox_cookie: None,
+            auto_reauth: true,
         }
     }
 }

--- a/src/client/rustblox_client.rs
+++ b/src/client/rustblox_client.rs
@@ -1,4 +1,5 @@
 use crate::error::{ClientError, RequestError, RobloxApiError, RobloxApiErrors};
+use async_recursion::async_recursion;
 use reqwest::header::HeaderMap;
 use reqwest::Method;
 use serde::de::DeserializeOwned;
@@ -15,6 +16,7 @@ pub struct RustbloxClient {
     pub(crate) reqwest_client: reqwest::Client,
     pub(crate) roblox_cookie: Option<String>,
     pub(crate) csrf_token: Option<String>,
+    pub(crate) auto_reauth: bool,
 }
 
 impl RustbloxClient {
@@ -95,6 +97,11 @@ impl RustbloxClient {
     }
 
     /// Makes a request to the Roblox API.
+    /// If the endpoint returns a 403 error and this function determines that the Client's
+    /// `x-csrf-token` is invalid, it will attempt to reauthenticate itself if `Client.auto_reauth`
+    /// is set to `true`. This value can be set while building the client.
+    /// The Client will only attempt reauthentication once (see the definition of insanity
+    /// for why).
     ///
     /// # Panics
     ///
@@ -106,12 +113,13 @@ impl RustbloxClient {
     /// This function will return an error if:
     /// - You attempt to contact an endpoint that requires authentication while unauthenticated.
     /// - The endpoint responds with an error.
-    /// - Your `.ROBLOSECURITY` cookie or `x-csrf-token` are invalid. In this case, you will get a [`RequestError::NotAuthenticated`].
-    /// You can call the `.login()` method to reauthenticate. I'm working on making this an automatic thing.
-    ///
+    /// - Your `.ROBLOSECURITY` cookie or `x-csrf-token` are invalid and automatic reauthentication failed
+    /// or was not enabled. In either case, you will get a [`RequestError::ReauthenticationFailed`].
+    #[async_recursion::async_recursion]
     pub(crate) async fn make_request<T>(
-        &self,
+        &mut self,
         components: RequestComponents,
+        tried_reauth: bool,
     ) -> Result<T, RequestError>
     where
         T: DeserializeOwned,
@@ -122,7 +130,7 @@ impl RustbloxClient {
 
         let mut request = self
             .reqwest_client
-            .request(components.method, components.url.clone());
+            .request(components.method.clone(), components.url.clone());
         if components.needs_auth {
             request = request
                 .header("Cookie", self.roblox_cookie().unwrap())
@@ -130,21 +138,16 @@ impl RustbloxClient {
         }
 
         if components.headers.is_some() {
-            request = request.headers(components.headers.unwrap());
+            request = request.headers(components.headers.clone().unwrap());
         }
         if components.body.is_some() {
-            request = request.body(components.body.unwrap());
+            request = request.body(components.body.clone().unwrap());
         }
 
         let response = request
             .send()
             .await
             .map_err(|e| RequestError::RequestError(components.url.clone(), e.to_string()))?;
-
-        if response.status().as_u16() == 403 {
-            // Current CSRF token is bad, refresh is necessary
-            return Err(RequestError::NotAuthenticated);
-        }
 
         if !response.status().is_success() {
             let status_code = response.status().as_u16();
@@ -153,9 +156,44 @@ impl RustbloxClient {
                 let err_body = response.json::<RobloxApiErrors>().await.map_err(|e| {
                     RequestError::RequestError(
                         components.url.clone(),
-                        format!("Couldn't parse error body json:\n{}", e.to_string()),
+                        format!("Couldn't parse error body json:\n{}", e),
                     )
                 })?;
+
+                if status_code == 401 {
+                    // Bad cookie
+                    return Err(RequestError::ExpiredCookie);
+                }
+
+                if status_code == 403 {
+                    // We need to find out if the Roblox API wants us to reauthenticate or if
+                    // the error is for a different reason
+                    let try_first_error = err_body.errors.first();
+                    if try_first_error.is_none() {
+                        return Err(RequestError::ClientError(
+                            components.url,
+                            status_code,
+                            err_body,
+                        ));
+                    }
+                    let first_error = try_first_error.unwrap();
+
+                    // Code 0 == bad CSRF token
+                    if first_error.code == 0 {
+                        if self.auto_reauth && !tried_reauth {
+                            self.login()
+                                .await
+                                .map_err(|e| RequestError::ReauthenticationFailed(e.to_string()))?;
+
+                            return self.make_request::<T>(components, true).await;
+                        }
+                        return Err(RequestError::ReauthenticationFailed(
+                            "Automatic reauthentication either not enabled or already tried"
+                                .to_string(),
+                        ));
+                    }
+                }
+
                 Err(RequestError::ClientError(
                     components.url,
                     status_code,

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -20,6 +20,10 @@ pub enum RequestError {
     /// The user tried to use an endpoint that requires authentication
     /// without being authenticated
     NotAuthenticated,
+    /// Automatic client reauthentication failed
+    ReauthenticationFailed(String),
+    /// The `.ROBLOSECURITY` cookie in use expired
+    ExpiredCookie,
     /// There was an error sending the request
     RequestError(String, String),
     /// The server returned a 400-class error code (client error).
@@ -52,6 +56,10 @@ impl Display for RequestError {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::NotAuthenticated => f.write_str("You need to be logged in to use this endpoint!"),
+            Self::ReauthenticationFailed(msg) => {
+                f.write_str(format!("Automatic reauthentication failed:\n{msg}").as_str())
+            }
+            Self::ExpiredCookie => f.write_str("The .ROBLOSECURITY cookie expired."),
             Self::RequestError(url, err) => {
                 f.write_str(format!("Had an error sending the request to {url}:\n{err}").as_str())
             }

--- a/src/routes/unauthenticated/user/user_info.rs
+++ b/src/routes/unauthenticated/user/user_info.rs
@@ -43,7 +43,7 @@ impl RustbloxClient {
     ///
     /// This function returns an error if the request could not be made, or if the endpoint responded with an error.
     pub async fn get_previous_usernames(
-        &self,
+        &mut self,
         id: usize,
         limit: Option<usize>,
         cursor: Option<String>,
@@ -70,7 +70,7 @@ impl RustbloxClient {
         };
 
         let previous_usernames_data = self
-            .make_request::<PreviousUsernamesPage>(components)
+            .make_request::<PreviousUsernamesPage>(components, false)
             .await?;
         let mut previous_usernames: Vec<String> = Vec::new();
         for username in previous_usernames_data.data {
@@ -84,7 +84,7 @@ impl RustbloxClient {
     /// # Errors
     ///
     /// This function returns an error if the request could not be made, or if the endpoint responded with an error.
-    pub async fn get_user_info(&self, id: usize) -> Result<UserInfo, RequestError> {
+    pub async fn get_user_info(&mut self, id: usize) -> Result<UserInfo, RequestError> {
         let url = format!("{}/users/{}", BASE_URL, id);
         let components = RequestComponents {
             needs_auth: false,
@@ -94,13 +94,13 @@ impl RustbloxClient {
             body: None,
         };
 
-        let user_info = self.make_request::<UserInfo>(components).await?;
+        let user_info = self.make_request::<UserInfo>(components, false).await?;
 
         Ok(user_info)
     }
 
     pub async fn get_users_from_ids(
-        &self,
+        &mut self,
         ids: Vec<usize>,
         exclude_banned: bool,
     ) -> Result<Vec<MinimalUserInfo>, RequestError> {
@@ -127,7 +127,7 @@ impl RustbloxClient {
         };
 
         let response = self
-            .make_request::<MinimalUserInfoObject>(components)
+            .make_request::<MinimalUserInfoObject>(components, false)
             .await?;
 
         let mut user_info_vec: Vec<MinimalUserInfo> = Vec::new();
@@ -139,7 +139,7 @@ impl RustbloxClient {
     }
 
     pub async fn get_users_from_usernames(
-        &self,
+        &mut self,
         usernames: Vec<&str>,
         exclude_banned: bool,
     ) -> Result<Vec<MinimalUserInfoWithRequestedName>, RequestError> {
@@ -166,7 +166,7 @@ impl RustbloxClient {
         };
 
         let response = self
-            .make_request::<MinimalUserInfoWithReqdObject>(components)
+            .make_request::<MinimalUserInfoWithReqdObject>(components, false)
             .await?;
 
         let mut user_info_vec: Vec<MinimalUserInfoWithRequestedName> = Vec::new();
@@ -178,7 +178,7 @@ impl RustbloxClient {
     }
 
     pub async fn search_user(
-        &self,
+        &mut self,
         username: String,
         limit: Option<usize>,
         page_cursor: Option<String>,
@@ -200,7 +200,9 @@ impl RustbloxClient {
             body: None,
         };
 
-        let response = self.make_request::<UserSearchPage>(components).await?;
+        let response = self
+            .make_request::<UserSearchPage>(components, false)
+            .await?;
 
         Ok(response)
     }


### PR DESCRIPTION
Add automatic reauthentication.
**NOTE**: This feature is currently untested as I haven't implemented any authenticated endpoints in `main` yet. I'll be testing it in the `authed_group_endpoints branch`, though.