### PR TITLE
Finish unauthenticated group membership endpoints

### DIFF
--- a/src/routes/authenticated/group/TODO.md
+++ b/src/routes/authenticated/group/TODO.md
@@ -13,7 +13,7 @@
 - [x] Exile user `DELETE /v1/groups/{groupId}/users/{userId}`
 - [x] Update a user's role in a group `PATCH /v1/groups/{groupId}/users/{userId}`
 - [x] Get roles `GET /v1/groups/{groupId}/roles` (NA)
-- [ ] Get users in a role `GET /v1/groups/{groupId}/roles/{roleSetId}/users` (NA)
-- [ ] Get list of members `GET /v1/groups/{groupId}/users` (NA)
+- [x] Get users in a role `GET /v1/groups/{groupId}/roles/{roleSetId}/users` (NA)
+- [x] Get list of members `GET /v1/groups/{groupId}/users` (NA)
 - [ ] Get groups of authed user's friends `GET /v1/users/{userId}/friends/groups/roles` (NA)
 - [x] Get group roles for user `GET /v1/users/{userId}/groups/roles` (NA)

--- a/src/routes/authenticated/group/membership.rs
+++ b/src/routes/authenticated/group/membership.rs
@@ -2,7 +2,7 @@ use reqwest::header::{HeaderMap, HeaderValue};
 use reqwest::Method;
 use crate::client::{RequestComponents, RustbloxClient};
 use crate::error::{RequestError, RobloxApiError, RobloxApiErrors};
-use crate::structs::group::{GroupRole, GroupRolesList, JoinRequest, JoinRequestPage, UserGroupList};
+use crate::structs::group::{GroupRole, JoinRequest, JoinRequestPage};
 
 const BASE_URL: &str = "https://groups.roblox.com";
 
@@ -140,55 +140,6 @@ impl RustbloxClient {
             .await?;
 
         Ok(())
-    }
-
-    /// **MUST AUTHENTICATE**
-    ///
-    /// Gets a list of the group's roles.
-    ///
-    /// # Errors
-    ///
-    /// This function will error if:
-    /// - You do not have a `.ROBLOSECURITY` cookie set.
-    /// - The endpoint responds with an error.
-    pub async fn get_group_roles(&mut self, group_id: usize) -> Result<GroupRolesList, RequestError> {
-        let url = format!("{BASE_URL}/v1/groups/{group_id}/roles");
-        
-        let components = RequestComponents {
-            needs_auth: true,
-            method: Method::GET,
-            url,
-            headers: None,
-            body: None,
-        };
-        let ranks = self
-            .make_request::<GroupRolesList>(components, false)
-            .await?;
-        Ok(ranks)
-    }
-
-    /// This doesn't need authentication and will be moved at a later date.
-    /// TODO: Move this to unauthenticated group endpoints
-    ///
-    /// Gets a list of groups that a given `user_id` is in, along with their role in each group.
-    ///
-    /// This function will error if:
-    /// - The endpoint responds with an error.
-    pub async fn get_user_group_roles(&mut self, user_id: usize) -> Result<UserGroupList, RequestError> {
-        let url = format!("{BASE_URL}/v1/users/{user_id}/groups/roles");
-
-        let components = RequestComponents {
-            needs_auth: false,
-            method: Method::GET,
-            url,
-            headers: None,
-            body: None,
-        };
-        let info = self
-            .make_request::<UserGroupList>(components, false)
-            .await?;
-
-        Ok(info)
     }
 
     /// **MUST AUTHENTICATE**

--- a/src/routes/unauthenticated/group/membership.rs
+++ b/src/routes/unauthenticated/group/membership.rs
@@ -1,0 +1,53 @@
+use reqwest::Method;
+use crate::client::{RequestComponents, RustbloxClient};
+use crate::error::RequestError;
+use crate::structs::group::{GroupRolesList, UserGroupList};
+
+const BASE_URL: &str = "https://groups.roblox.com";
+
+impl RustbloxClient {
+    /// Gets a list of the group's roles.
+    ///
+    /// # Errors
+    ///
+    /// This function will error if:
+    /// - The endpoint responds with an error.
+    pub async fn get_group_roles(&mut self, group_id: usize) -> Result<GroupRolesList, RequestError> {
+        let url = format!("{BASE_URL}/v1/groups/{group_id}/roles");
+
+        let components = RequestComponents {
+            needs_auth: false,
+            method: Method::GET,
+            url,
+            headers: None,
+            body: None,
+        };
+        let ranks = self
+            .make_request::<GroupRolesList>(components, false)
+            .await?;
+        Ok(ranks)
+    }
+
+    /// This doesn't need authentication and will be moved at a later date.
+    ///
+    /// Gets a list of groups that a given `user_id` is in, along with their role in each group.
+    ///
+    /// This function will error if:
+    /// - The endpoint responds with an error.
+    pub async fn get_user_group_roles(&mut self, user_id: usize) -> Result<UserGroupList, RequestError> {
+        let url = format!("{BASE_URL}/v1/users/{user_id}/groups/roles");
+
+        let components = RequestComponents {
+            needs_auth: false,
+            method: Method::GET,
+            url,
+            headers: None,
+            body: None,
+        };
+        let info = self
+            .make_request::<UserGroupList>(components, false)
+            .await?;
+
+        Ok(info)
+    }
+}

--- a/src/routes/unauthenticated/group/mod.rs
+++ b/src/routes/unauthenticated/group/mod.rs
@@ -1,0 +1,1 @@
+mod membership;

--- a/src/routes/unauthenticated/mod.rs
+++ b/src/routes/unauthenticated/mod.rs
@@ -1,1 +1,2 @@
 mod user;
+mod group;

--- a/src/structs/group/mod.rs
+++ b/src/structs/group/mod.rs
@@ -82,3 +82,13 @@ pub struct UserRoleInGroup {
     pub name: String,
     pub rank: u8,
 }
+
+/// Represents a page of users in a group's role. Used in
+/// [`get_group_role_members`](crate::client::RustbloxClient::get_group_role_members)
+#[derive(Deserialize, Debug, Clone, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct RoleMembersPage {
+    pub previous_page_cursor: Option<String>,
+    pub next_page_cursor: Option<String>,
+    pub data: Vec<MinimalUserInfo>
+}

--- a/src/structs/group/mod.rs
+++ b/src/structs/group/mod.rs
@@ -51,9 +51,19 @@ pub struct UserGroupList {
 /// and info about the user's rank/role in it. Used as a component
 /// of [`UserGroupList`].
 #[derive(Deserialize, Debug, Clone, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
 pub struct UserGroup {
     pub group: UserGroupInfo,
     pub role: UserRoleInGroup,
+    #[serde(default)]
+    pub is_primary_group: bool,
+}
+
+/// Contains information about a group's shout, if there is one.
+#[derive(Deserialize, Debug, Clone, PartialEq, Eq)]
+pub struct GroupShout {
+    pub body: String,
+    pub poster: MinimalUserInfo,
 }
 
 /// Contains all the information about a group that a certain user
@@ -65,13 +75,11 @@ pub struct UserGroupInfo {
     pub name: String,
     pub description: String,
     pub owner: MinimalUserInfo,
-    pub shout: Option<String>,
+    pub shout: Option<GroupShout>,
     pub member_count: usize,
     pub is_builders_club_only: bool,
     pub public_entry_allowed: bool,
     pub has_verified_badge: bool,
-    #[serde(default)]
-    pub is_primary_group: bool,
 }
 
 /// Contains information about a user's role in a certain group. Used
@@ -90,13 +98,12 @@ pub struct UserRoleInGroup {
 pub struct RoleMembersPage {
     pub previous_page_cursor: Option<String>,
     pub next_page_cursor: Option<String>,
-    pub data: Vec<MinimalUserInfo>
+    pub data: Vec<MinimalUserInfo>,
 }
 
 /// Contains information about a member of a group. Used as a component
 /// of [`GroupMembersPage`](GroupMembersPage)
 #[derive(Deserialize, Debug, Clone, PartialEq, Eq)]
-#[serde(rename_all = "camelCase")]
 pub struct GroupMemberInfo {
     pub user: MinimalUserInfo,
     pub role: GroupRole,
@@ -109,5 +116,5 @@ pub struct GroupMemberInfo {
 pub struct GroupMembersPage {
     pub previous_page_cursor: Option<String>,
     pub next_page_cursor: Option<String>,
-    pub data: Vec<GroupMemberInfo>
+    pub data: Vec<GroupMemberInfo>,
 }

--- a/src/structs/group/mod.rs
+++ b/src/structs/group/mod.rs
@@ -26,7 +26,7 @@ pub struct JoinRequestPage {
 pub struct GroupRole {
     pub id: usize,
     pub name: String,
-    pub description: String,
+    pub description: Option<String>,
     pub rank: u8,
     pub member_count: usize,
 }

--- a/src/structs/group/mod.rs
+++ b/src/structs/group/mod.rs
@@ -28,7 +28,7 @@ pub struct GroupRole {
     pub name: String,
     pub description: Option<String>,
     pub rank: u8,
-    pub member_count: usize,
+    pub member_count: Option<usize>,
 }
 
 /// Represents a list of roles in a group. Used in
@@ -91,4 +91,23 @@ pub struct RoleMembersPage {
     pub previous_page_cursor: Option<String>,
     pub next_page_cursor: Option<String>,
     pub data: Vec<MinimalUserInfo>
+}
+
+/// Contains information about a member of a group. Used as a component
+/// of [`GroupMembersPage`](GroupMembersPage)
+#[derive(Deserialize, Debug, Clone, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct GroupMemberInfo {
+    pub user: MinimalUserInfo,
+    pub role: GroupRole,
+}
+
+/// Represents a page of information about the members of a group.
+/// Used in [`get_group_members`](crate::client::RustbloxClient::get_group_members)
+#[derive(Deserialize, Debug, Clone, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct GroupMembersPage {
+    pub previous_page_cursor: Option<String>,
+    pub next_page_cursor: Option<String>,
+    pub data: Vec<GroupMemberInfo>
 }

--- a/src/tests/group_auth_tests.rs
+++ b/src/tests/group_auth_tests.rs
@@ -53,25 +53,9 @@ async fn kick_user() {
 }
 
 #[tokio::test]
-async fn get_group_roles() {
-    let mut client = create_authed_client().await;
-    let result = client.get_group_roles(5681740).await;
-    println!("{:#?}", result);
-    assert!(result.is_ok());
-}
-
-#[tokio::test]
 async fn set_user_rank() {
     let mut client = create_authed_client().await;
     let result = client.set_user_role_in_group(5681740, 1115834788, 6).await;
-    println!("{:#?}", result);
-    assert!(result.is_ok());
-}
-
-#[tokio::test]
-async fn get_user_group_roles() {
-    let mut client = create_authed_client().await;
-    let result = client.get_user_group_roles(68429027).await;
     println!("{:#?}", result);
     assert!(result.is_ok());
 }

--- a/src/tests/group_unauth_tests.rs
+++ b/src/tests/group_unauth_tests.rs
@@ -1,0 +1,21 @@
+use crate::client::builder::RustbloxClientBuilder;
+
+#[tokio::test]
+async fn get_group_roles() {
+    let mut client = RustbloxClientBuilder::new()
+        .build()
+        .unwrap();
+    let result = client.get_group_roles(5681740).await;
+    println!("{:#?}", result);
+    assert!(result.is_ok());
+}
+
+#[tokio::test]
+async fn get_user_group_roles() {
+    let mut client = RustbloxClientBuilder::new()
+        .build()
+        .unwrap();
+    let result = client.get_user_group_roles(68429027).await;
+    println!("{:#?}", result);
+    assert!(result.is_ok());
+}

--- a/src/tests/group_unauth_tests.rs
+++ b/src/tests/group_unauth_tests.rs
@@ -1,6 +1,22 @@
 use crate::client::builder::RustbloxClientBuilder;
 
 #[tokio::test]
+async fn get_group_members() {
+    let mut client = RustbloxClientBuilder::new()
+        .build()
+        .unwrap();
+    let result = client
+        .get_group_members(
+            5681740,
+            None,
+            None,
+            None
+        ).await;
+    println!("{:#?}", result);
+    assert!(result.is_ok());
+}
+
+#[tokio::test]
 async fn get_group_roles() {
     let mut client = RustbloxClientBuilder::new()
         .build()

--- a/src/tests/group_unauth_tests.rs
+++ b/src/tests/group_unauth_tests.rs
@@ -19,3 +19,19 @@ async fn get_user_group_roles() {
     println!("{:#?}", result);
     assert!(result.is_ok());
 }
+
+#[tokio::test]
+async fn get_members_in_group_role() {
+    let mut client = RustbloxClientBuilder::new()
+        .build()
+        .unwrap();
+    let result = client.get_group_role_members(
+        5681740,
+        85311978,
+        None,
+        None,
+        None
+    ).await;
+    println!("{:#?}", result);
+    assert!(result.is_ok());
+}

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -3,6 +3,7 @@ mod user_unauth_tests;
 mod group_auth_tests;
 mod auto_reauth;
 mod user_auth_tests;
+mod group_unauth_tests;
 
 use std::fs::{canonicalize, File};
 use std::io::Read;


### PR DESCRIPTION
The only endpoint that isn't included is `/v1/users/{userId}/friends/groups/roles` since I suspect it is authenticated despite not having any error descriptions that match other authenticated endpoints.